### PR TITLE
feat: implement command verifier with shell execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Tests/
   Types.lean           isTerminal behavior tests
   Parser.lean          JSON parser tests (all verify types, error cases)
   Integration.lean     TOML converter and SpecLoader end-to-end tests
+  Verifier.lean        Command verifier tests (shell execution, exit codes, output capture)
 specs/                 qed's own specs (dogfooding)
   build.spec.json          Build integrity — compile, test, no sorry
   state-machine.spec.toml  State machine correctness — proof + agentReview

--- a/Qed.lean
+++ b/Qed.lean
@@ -3,3 +3,4 @@ import Qed.StateMachine
 import Qed.Parser
 import Qed.TomlConverter
 import Qed.SpecLoader
+import Qed.Verifier

--- a/Qed/Verifier.lean
+++ b/Qed/Verifier.lean
@@ -1,0 +1,50 @@
+import Qed.Types
+
+namespace Qed.Verifier
+
+open Qed
+
+/-- Truncate a string to the last `maxLength` characters, prepending a truncation marker. -/
+private def truncate (s : String) (maxLength : Nat) : String :=
+  if s.length > maxLength then
+    "...(truncated)\n" ++ (s.drop (s.length - maxLength))
+  else s
+
+/-- Run a shell command and return pass/fail based on exit code.
+    Captures stdout and stderr, truncates to last 2000 chars.
+    TODO: `timeout` is parsed and stored but not yet enforced. Process-level
+    timeout requires `IO.Process.spawn` + async kill, tracked for a future PR. -/
+private def verifyCommand (command : String) (_timeout : Nat) : IO VerificationResult := do
+  let result ← IO.Process.output {
+    cmd := "/bin/sh"
+    args := #["-c", command]
+  }
+  let stdout := result.stdout.trimAscii.toString
+  let stderr := result.stderr.trimAscii.toString
+  let combined := stdout ++ (if stderr.isEmpty then "" else "\nSTDERR:\n" ++ stderr)
+  let details := truncate combined 2000
+  if result.exitCode == 0 then
+    return .pass details
+  else
+    return .fail s!"exit code {result.exitCode}\n{details}"
+
+/-- Verify a single acceptance criterion. -/
+def verifyCriterion (criterion : AcceptanceCriterion) : IO VerificationResult := do
+  match criterion.verify with
+  | .command run timeout => verifyCommand run timeout
+  | .agentReview prompt model =>
+    return .skipped s!"agentReview not yet implemented (model: {model}, prompt length: {prompt.length})"
+  | .property run timeout =>
+    return .skipped s!"property testing not yet implemented (run: {run}, timeout: {timeout})"
+  | .proof prover target =>
+    return .skipped s!"proof verification not yet implemented (prover: {prover}, target: {target})"
+  | .human instruction =>
+    return .needsHuman instruction
+
+/-- Verify all criteria in a spec, returning results paired with descriptions. -/
+def verifyAll (criteria : List AcceptanceCriterion) : IO (List (String × VerificationResult)) := do
+  criteria.mapM fun criterion => do
+    let result ← verifyCriterion criterion
+    return (criterion.description, result)
+
+end Qed.Verifier

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -1,6 +1,7 @@
 import Tests.Types
 import Tests.Parser
 import Tests.Integration
+import Tests.Verifier
 
 /-- Run a named test, print result, return whether it passed. -/
 def runTest (name : String) (test : IO Bool) : IO Bool := do
@@ -13,7 +14,7 @@ def runTest (name : String) (test : IO Bool) : IO Bool := do
 
 def main : IO UInt32 := do
   let tests : List (String × IO Bool) :=
-    typeTests ++ parserTests ++ integrationTests
+    typeTests ++ parserTests ++ integrationTests ++ verifierTests
 
   let mut failedCount : Nat := 0
   for (name, test) in tests do

--- a/Tests/Verifier.lean
+++ b/Tests/Verifier.lean
@@ -1,0 +1,124 @@
+import Qed
+import Qed.Verifier
+
+open Qed
+open Qed.Verifier
+
+def testVerifyCommandReturnsPassOnExitZero : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "runs true"
+    verify := .command "true"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  return result.isPassed
+
+def testVerifyCommandReturnsFailOnNonZeroExit : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "runs false"
+    verify := .command "false"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  return result.isFailed
+
+def testVerifyCommandCapturesStdout : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "echoes hello"
+    verify := .command "echo hello"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  match result with
+  | .pass details => return details.contains "hello"
+  | _ => return false
+
+def testVerifyCommandCapturesStderr : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "writes to stderr"
+    verify := .command "echo error >&2"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  match result with
+  | .pass details => return details.contains "error" && details.contains "STDERR"
+  | _ => return false
+
+def testVerifyCommandHandlesPipedCommands : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "pipes work"
+    verify := .command "echo hello | grep hello"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  return result.isPassed
+
+def testVerifyCommandReturnsFailForMissingCommand : IO Bool := do
+  -- Arrange
+  let criterion : AcceptanceCriterion := {
+    description := "runs nonexistent command"
+    verify := .command "this_command_does_not_exist_qed_test_2024"
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  return result.isFailed
+
+def testVerifyHumanReturnsNeedsHuman : IO Bool := do
+  -- Arrange
+  let instruction := "Please verify the UI looks correct"
+  let criterion : AcceptanceCriterion := {
+    description := "manual check"
+    verify := .human instruction
+  }
+  -- Act
+  let result ← verifyCriterion criterion
+  -- Assert
+  match result with
+  | .needsHuman returnedInstruction => return returnedInstruction == instruction
+  | _ => return false
+
+def testVerifyAllReturnsResultsForAllCriteria : IO Bool := do
+  -- Arrange
+  let criteria : List AcceptanceCriterion := [
+    { description := "passes", verify := .command "true" },
+    { description := "fails", verify := .command "false" },
+    { description := "manual", verify := .human "check it" }
+  ]
+  -- Act
+  let results ← verifyAll criteria
+  -- Assert
+  if results.length != 3 then return false
+  let descriptions := results.map (·.1)
+  let firstPassed := match results[0]? with
+    | some (_, r) => r.isPassed
+    | none => false
+  let secondFailed := match results[1]? with
+    | some (_, r) => r.isFailed
+    | none => false
+  let thirdHuman := match results[2]? with
+    | some (_, .needsHuman _) => true
+    | _ => false
+  return descriptions == ["passes", "fails", "manual"] &&
+    firstPassed && secondFailed && thirdHuman
+
+def verifierTests : List (String × IO Bool) := [
+  ("testVerifyCommandReturnsPassOnExitZero", testVerifyCommandReturnsPassOnExitZero),
+  ("testVerifyCommandReturnsFailOnNonZeroExit", testVerifyCommandReturnsFailOnNonZeroExit),
+  ("testVerifyCommandCapturesStdout", testVerifyCommandCapturesStdout),
+  ("testVerifyCommandCapturesStderr", testVerifyCommandCapturesStderr),
+  ("testVerifyCommandHandlesPipedCommands", testVerifyCommandHandlesPipedCommands),
+  ("testVerifyCommandReturnsFailForMissingCommand", testVerifyCommandReturnsFailForMissingCommand),
+  ("testVerifyHumanReturnsNeedsHuman", testVerifyHumanReturnsNeedsHuman),
+  ("testVerifyAllReturnsResultsForAllCriteria", testVerifyAllReturnsResultsForAllCriteria)
+]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -16,7 +16,7 @@ lean_exe «qed» where
   root := `Main
 
 lean_lib «TestLib» where
-  roots := #[`Tests.Types, `Tests.Parser, `Tests.Integration]
+  roots := #[`Tests.Types, `Tests.Parser, `Tests.Integration, `Tests.Verifier]
 
 @[test_driver]
 lean_exe «tests» where


### PR DESCRIPTION
## Summary

- Add `Qed.Verifier` module that dispatches verification based on `VerifyType`, with the `command` type fully implemented via `/bin/sh -c` shell execution
- Capture stdout/stderr, truncate to last 2000 chars, and check exit codes for pass/fail
- Other verify types (`agentReview`, `property`, `proof`) return `.skipped` placeholders; `human` returns `.needsHuman`
- Timeout field is parsed and stored but not yet enforced (requires `IO.Process.spawn` + async kill — tracked for a future PR)

## Changes

- **`Qed/Verifier.lean`** — `verifyCommand`, `verifyCriterion`, `verifyAll`
- **`Tests/Verifier.lean`** — 8 tests: exit code pass/fail, stdout/stderr capture, piped commands, missing commands, human criteria, `verifyAll` aggregation
- **`Qed.lean`** — added `import Qed.Verifier`
- **`lakefile.lean`** — added `Tests.Verifier` to TestLib roots
- **`Tests/Main.lean`** — added `import Tests.Verifier`, included `verifierTests` in test list
- **`AGENTS.md`** — added `Tests/Verifier.lean` to architecture tree

## Test plan

- [x] `lake build` passes
- [x] `lake test` passes — all 38 tests (30 existing + 8 new)
- [ ] CI build + test
- [ ] No `sorry` in source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)