### PR TITLE
feat: add serializer with roundtrip proof against parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Qed/Proofs/
   ParserProperties.lean   parseCiSchedule completeness and rejection
   TomlProperties.lean     setNested/appendArray structural integrity
   TomlJsonValidity.lean   TOML→JSON pipeline totality and error propagation
-  Roundtrip.lean          Serializer↔parser roundtrip (specToJson ∘ parseFromJson = id)
+  Roundtrip.lean          Serializer↔parser roundtrip (parseFromJson ∘ specToJson = ok)
 Tests/
   Main.lean            Test runner (imports all test modules)
   Types.lean           isTerminal behavior tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,13 @@ Main.lean              CLI entry point (qed run, qed verify, qed parse, qed vers
 Qed/
   Types.lean           Core types (VerifyType, SpecMode, Spec, LoopState)
   SpecLoader.lean      Load and list spec files from disk
-  Parser.lean          JSON spec parser (Lean.Json → Spec)
+  Parser.lean          JSON spec parser (Lean.Json → Spec, parseFromJson for roundtrip proofs)
   TomlParser.lean      Pure Lean TOML parser (no external dependencies)
   TomlConverter.lean   TOML → JSON conversion (thin wrapper around TomlParser)
   StateMachine.lean    Pure transition function (proven core)
   Verifier.lean        Verification dispatch (command, agent, property, proof)
   Output.lean          JSON result serialization (--json flag support)
+  Serializer.lean      Spec → JSON serialization (roundtrip-proven against Parser)
 Qed/Proofs/
   Termination.lean     Loop termination, progress, and fuel decrease
   StuckDetection.lean  Stuck iff same failures for stuckThreshold iterations
@@ -30,6 +31,7 @@ Qed/Proofs/
   ParserProperties.lean   parseCiSchedule completeness and rejection
   TomlProperties.lean     setNested/appendArray structural integrity
   TomlJsonValidity.lean   TOML→JSON pipeline totality and error propagation
+  Roundtrip.lean          Serializer↔parser roundtrip (specToJson ∘ parseFromJson = id)
 Tests/
   Main.lean            Test runner (imports all test modules)
   Types.lean           isTerminal behavior tests
@@ -42,7 +44,7 @@ specs/                 qed's own specs (dogfooding)
   build.spec.json          Build integrity — compile, test, no sorry
   cli.spec.toml            CLI + verifier + output correctness — 1 proof + agent
   state-machine.spec.toml  State machine correctness — 5 proofs + agent
-  parser.spec.toml         Parser correctness — 2 proofs + agent
+  parser.spec.toml         Parser correctness — 3 proofs + agent
   verify-mode.spec.toml    Verify mode correctness — 2 proofs + command + agent
   docs.spec.toml           Documentation accuracy — freshness + agent
 DocGen/
@@ -158,6 +160,12 @@ The `Qed/Proofs/` directory contains formal proofs verified by Lean 4's kernel. 
 | `TomlJsonValidity.lean` | `toJson_array` | Arrays map to JSON arrays via toJsonList |
 | `TomlJsonValidity.lean` | `toJson_empty_table` | Empty table produces empty JSON object |
 | `TomlJsonValidity.lean` | `toJson_empty_array` | Empty array produces empty JSON array |
+| `Roundtrip.lean` | `ciSchedule_roundtrip` | parseCiSchedule inverts ciScheduleToString |
+| `Roundtrip.lean` | `verifyType_roundtrip` | parseVerifyType inverts verifyTypeToJson for every constructor |
+| `Roundtrip.lean` | `criterion_roundtrip` | parseCriterion inverts criterionToJson |
+| `Roundtrip.lean` | `workerConfig_roundtrip` | parseWorkerConfig inverts workerConfigToJson |
+| `Roundtrip.lean` | `criteria_list_roundtrip` | Element-wise roundtrip lifts to list-level mapM roundtrip |
+| `Roundtrip.lean` | `spec_roundtrip` | **Main theorem:** parseFromJson inverts specToJson for all well-formed specs |
 
 ## Repo-specific conventions
 

--- a/Qed/Parser.lean
+++ b/Qed/Parser.lean
@@ -6,19 +6,19 @@ namespace Qed.Parser
 open Lean Qed
 
 /-- Helper: get a required string field from a JSON object. -/
-private def requireString (json : Json) (field : String) : Except String String :=
+def requireString (json : Json) (field : String) : Except String String :=
   match json.getObjValAs? String field with
   | .ok value => .ok value
   | .error _ => .error s!"missing or invalid field '{field}': expected string"
 
 /-- Helper: get an optional string field with a default. -/
-private def optionalString (json : Json) (field : String) (default : String) : String :=
+def optionalString (json : Json) (field : String) (default : String) : String :=
   match json.getObjValAs? String field with
   | .ok value => value
   | .error _ => default
 
 /-- Helper: get an optional natural number field with a default. -/
-private def optionalNat (json : Json) (field : String) (default : Nat) : Except String Nat :=
+def optionalNat (json : Json) (field : String) (default : Nat) : Except String Nat :=
   match json.getObjValAs? Nat field with
   | .ok value => .ok value
   | .error _ =>
@@ -83,9 +83,8 @@ def parseWorkerConfig (json : Json) : Except String WorkerConfig := do
   let timeout ← optionalNat json "timeout" 3600
   .ok { command, workdir, timeout }
 
-/-- Parse a Spec from a JSON string. -/
-def parseJson (input : String) : Except String Spec := do
-  let json ← Json.parse input
+/-- Parse a Spec from a parsed JSON value. -/
+def parseFromJson (json : Json) : Except String Spec := do
   let name ← requireString json "name"
 
   -- Parse criteria
@@ -110,5 +109,10 @@ def parseJson (input : String) : Except String Spec := do
         .ok SpecMode.verify
 
   .ok { name, mode, criteria }
+
+/-- Parse a Spec from a JSON string. -/
+def parseJson (input : String) : Except String Spec := do
+  let json ← Json.parse input
+  parseFromJson json
 
 end Qed.Parser

--- a/Qed/Proofs/Roundtrip.lean
+++ b/Qed/Proofs/Roundtrip.lean
@@ -1,0 +1,124 @@
+import Qed.Types
+import Qed.Parser
+import Qed.Serializer
+
+set_option autoImplicit false
+
+namespace Qed.Proofs.Roundtrip
+
+open Qed Qed.Parser Qed.Serializer Lean
+
+/-! # Serializer–Parser roundtrip proofs
+
+The main result: `parseFromJson (specToJson spec) = .ok spec` for well-formed
+specs. This guarantees the serializer and parser agree on every field — any
+future mismatch breaks the proof at compile time. -/
+
+-- Level 1: CiSchedule roundtrip
+
+/-- parseCiSchedule inverts ciScheduleToString for every constructor. -/
+theorem ciSchedule_roundtrip (cs : CiSchedule) :
+    parseCiSchedule (ciScheduleToString cs) = .ok cs := by
+  cases cs <;> rfl
+
+-- Level 2: VerifyType roundtrip
+
+/-- parseVerifyType inverts verifyTypeToJson for every constructor. -/
+theorem verifyType_roundtrip (vt : VerifyType) :
+    parseVerifyType (verifyTypeToJson vt) = .ok vt := by
+  cases vt with
+  | command run timeout =>
+    simp [verifyTypeToJson, parseVerifyType, requireString, optionalNat,
+      Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  | agent prompt model =>
+    simp [verifyTypeToJson, parseVerifyType, requireString, optionalString,
+      Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  | property run timeout =>
+    simp [verifyTypeToJson, parseVerifyType, requireString, optionalNat,
+      Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  | proof prover target =>
+    simp [verifyTypeToJson, parseVerifyType, requireString,
+      Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  | human instruction =>
+    simp [verifyTypeToJson, parseVerifyType, requireString,
+      Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+
+-- Level 3: AcceptanceCriterion roundtrip
+
+/-- parseCriterion inverts criterionToJson. -/
+theorem criterion_roundtrip (criterion : AcceptanceCriterion) :
+    parseCriterion (criterionToJson criterion) = .ok criterion := by
+  simp [criterionToJson, parseCriterion, requireString,
+    Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  constructor
+  · exact verifyType_roundtrip criterion.verify
+  · exact ciSchedule_roundtrip criterion.ci
+
+-- Level 4: WorkerConfig roundtrip
+
+/-- parseWorkerConfig inverts workerConfigToJson. -/
+theorem workerConfig_roundtrip (worker : WorkerConfig) :
+    parseWorkerConfig (workerConfigToJson worker) = .ok worker := by
+  simp [workerConfigToJson, parseWorkerConfig, requireString, optionalString, optionalNat,
+    Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+
+-- Helper: lift element-wise roundtrip to List.mapM
+
+/-- If parsing inverts serialization for each element, mapM inverts map. -/
+theorem criteria_list_roundtrip (criteria : List AcceptanceCriterion) :
+    (criteria.map criterionToJson).mapM parseCriterion = Except.ok criteria := by
+  induction criteria with
+  | nil => simp
+  | cons head tail ih =>
+    simp only [List.map, List.mapM_cons]
+    simp [criterion_roundtrip head, ih]
+
+-- Level 5: Full Spec roundtrip
+
+/-- parseFromJson inverts specToJson for verify-mode specs with non-empty criteria. -/
+theorem spec_verify_roundtrip (name : String) (criteria : List AcceptanceCriterion)
+    (hne : criteria ≠ []) :
+    parseFromJson (specToJson { name, mode := .verify, criteria }) =
+      .ok { name, mode := .verify, criteria } := by
+  simp [specToJson, parseFromJson, requireString,
+    Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  constructor
+  · simp [Array.mapM]
+    exact criteria_list_roundtrip criteria
+  · simp [List.isEmpty]
+    cases criteria with
+    | nil => contradiction
+    | cons _ _ => simp
+
+/-- parseFromJson inverts specToJson for workerLoop-mode specs. -/
+theorem spec_workerLoop_roundtrip (name : String) (criteria : List AcceptanceCriterion)
+    (worker : WorkerConfig) (loopConfig : LoopConfig) :
+    parseFromJson (specToJson { name, mode := .workerLoop worker loopConfig, criteria }) =
+      .ok { name, mode := .workerLoop worker loopConfig, criteria } := by
+  simp [specToJson, parseFromJson, requireString, optionalNat,
+    Json.mkObj, Json.getObjValAs?, Json.getObjVal?]
+  constructor
+  · simp [Array.mapM]
+    exact criteria_list_roundtrip criteria
+  · exact workerConfig_roundtrip worker
+
+/-- **Main roundtrip theorem:** parsing the serialized JSON of any well-formed
+spec recovers the original spec exactly. Well-formed means verify-mode specs
+have at least one criterion (the parser rejects empty verify-mode specs). -/
+theorem spec_roundtrip (spec : Spec)
+    (h : spec.mode = .verify → spec.criteria ≠ []) :
+    parseFromJson (specToJson spec) = .ok spec := by
+  cases hmode : spec.mode with
+  | verify =>
+    have hne := h hmode
+    have : spec = { name := spec.name, mode := .verify, criteria := spec.criteria } := by
+      cases spec; simp_all
+    rw [this]
+    exact spec_verify_roundtrip spec.name spec.criteria hne
+  | workerLoop worker loopConfig =>
+    have : spec = { name := spec.name, mode := .workerLoop worker loopConfig, criteria := spec.criteria } := by
+      cases spec; simp_all
+    rw [this]
+    exact spec_workerLoop_roundtrip spec.name spec.criteria worker loopConfig
+
+end Qed.Proofs.Roundtrip

--- a/Qed/Serializer.lean
+++ b/Qed/Serializer.lean
@@ -1,0 +1,69 @@
+import Lean.Data.Json
+import Qed.Types
+
+set_option autoImplicit false
+
+namespace Qed.Serializer
+
+open Lean Qed
+
+/-- Serialize a CiSchedule to its string representation. -/
+def ciScheduleToString : CiSchedule → String
+  | .always => "always"
+  | .trunk => "trunk"
+  | .manual => "manual"
+
+/-- Serialize a VerifyType to JSON. -/
+def verifyTypeToJson : VerifyType → Json
+  | .command run timeout => Json.mkObj [
+      ("type", Json.str "command"),
+      ("run", Json.str run),
+      ("timeout", Lean.toJson timeout)]
+  | .agent prompt model => Json.mkObj [
+      ("type", Json.str "agent"),
+      ("prompt", Json.str prompt),
+      ("model", Json.str model)]
+  | .property run timeout => Json.mkObj [
+      ("type", Json.str "property"),
+      ("run", Json.str run),
+      ("timeout", Lean.toJson timeout)]
+  | .proof prover target => Json.mkObj [
+      ("type", Json.str "proof"),
+      ("prover", Json.str prover),
+      ("target", Json.str target)]
+  | .human instruction => Json.mkObj [
+      ("type", Json.str "human"),
+      ("instruction", Json.str instruction)]
+
+/-- Serialize an AcceptanceCriterion to JSON. -/
+def criterionToJson (criterion : AcceptanceCriterion) : Json := Json.mkObj [
+  ("description", Json.str criterion.description),
+  ("verify", verifyTypeToJson criterion.verify),
+  ("ci", Json.str (ciScheduleToString criterion.ci))]
+
+/-- Serialize a WorkerConfig to JSON. -/
+def workerConfigToJson (worker : WorkerConfig) : Json := Json.mkObj [
+  ("command", Json.str worker.command),
+  ("workdir", Json.str worker.workdir),
+  ("timeout", Lean.toJson worker.timeout)]
+
+/-- Serialize a Spec to JSON. All fields are always emitted (including defaults)
+to simplify roundtrip proofs. -/
+def specToJson (spec : Spec) : Json :=
+  let base := [
+    ("name", Json.str spec.name),
+    ("criteria", Json.arr (spec.criteria.map criterionToJson).toArray)]
+  let fields := match spec.mode with
+    | .workerLoop worker loopConfig =>
+      base ++ [
+        ("worker", workerConfigToJson worker),
+        ("maxIterations", Lean.toJson loopConfig.maxIterations),
+        ("stuckThreshold", Lean.toJson loopConfig.stuckThreshold)]
+    | .verify => base
+  Json.mkObj fields
+
+/-- Serialize a Spec to a JSON string. -/
+def serialize (spec : Spec) : String :=
+  (specToJson spec).pretty
+
+end Qed.Serializer

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Formal proofs verified by Lean 4's kernel:
 - **CI schedule parser completeness** — accepts exactly "always", "trunk", "manual"
 - **TOML key integrity** — `setNested` rejects duplicate keys, `appendArray` creates correctly
 - **TOML→JSON pipeline** — successful conversion implies successful parse; parse errors propagate
+- **Serializer↔parser roundtrip** — parsing serialized JSON recovers the original spec exactly
 
 ## Status
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -46,7 +46,7 @@ Two formal proofs verify the type-level separation between modes: verify mode ca
 
 ### 4. Parser correctness (`parser.spec.toml`)
 
-Two formal proofs verify CI schedule parsing: completeness (accepts exactly the three valid strings) and rejection (all other strings produce errors). Building-block proofs (TOML duplicate key rejection, array creation) live in the proof files. Agent reviews check the JSON and TOML parsers for data loss, correct defaults, and spec compliance.
+Three formal proofs verify parser correctness: CI schedule completeness (accepts exactly the three valid strings), CI schedule rejection (all other strings produce errors), and the serializer↔parser roundtrip (parsing serialized JSON recovers the original spec exactly). Building-block proofs (TOML duplicate key rejection, array creation, per-type roundtrips) live in the proof files. Agent reviews check the JSON and TOML parsers for data loss, correct defaults, and spec compliance.
 
 ### 5. CLI and verifier correctness (`cli.spec.toml`)
 

--- a/specs/parser.spec.toml
+++ b/specs/parser.spec.toml
@@ -26,6 +26,14 @@ type = "proof"
 prover = "lean4"
 target = "Qed.Proofs.ParserProperties.parseCiSchedule_rejects_invalid"
 
+[[criteria]]
+description = "Serializer→parser roundtrip: parsing serialized JSON recovers the original spec exactly"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.Roundtrip.spec_roundtrip"
+
 # --- Agent review ---
 
 [[criteria]]


### PR DESCRIPTION
## Summary

- Add `Qed/Serializer.lean` — `Spec → Json` serialization (the reverse of `Parser.lean`)
- Add `Qed/Proofs/Roundtrip.lean` — formal proof that `parseFromJson (specToJson spec) = .ok spec` for all well-formed specs
- Refactor `Parser.lean` to extract `parseFromJson : Json → Except String Spec` and make helpers non-private for proof access

The roundtrip proof is compositional (bottom-up): CiSchedule → VerifyType → AcceptanceCriterion → WorkerConfig → List → Spec. Any future field added to the parser or serializer without updating the other will break the proof at compile time.

6 new theorems, 0 `sorry`.

## Test plan

- [x] `lake build` — all proofs verified by Lean 4's kernel
- [x] `lake test` — all 69 tests pass
- [x] No `sorry` in proof files

🤖 Generated with [Claude Code](https://claude.com/claude-code)