### PR TITLE
feat: total fnmatch with proven glob semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Qed/
   Shell.lean           Shell command execution and quoting utilities
   Agent.lean           Shared agent invocation (env var constants, default commands)
   Integrity.lean       Content-addressed spec integrity (SHA-256 hashing, git checks)
-  Ignore.lean          .qedignore parsing and fnmatch glob matching (*, ?, [abc], [!abc], ! negation)
+  Ignore.lean          .qedignore parsing and total glob matching (*, ?, [abc], [!abc], ! negation)
   ContractLock.lean    Verification contract locking (glob expansion, theorem extraction, lock file I/O)
   SpecLoader.lean      Load and pin spec files from disk (returns Spec.Pinned)
   Parser.lean          JSON spec parser (Lean.Json → Spec, parseFromJson for roundtrip proofs)
@@ -44,7 +44,7 @@ Qed/Proofs/
   LockRoundtrip.lean      Lock file writer↔reader roundtrip (parseLockFileFromJson ∘ lockFileToJson = ok)
   ShellProperties.lean    shellQuote produces exactly one shell word; command-last structure
   VerifierProperties.lean Proof-target resolution and sorry detection
-  IgnoreProperties.lean   .qedignore parse output contract and pattern precedence
+  IgnoreProperties.lean   Glob semantics, .qedignore parse contract, pattern precedence
   GlobProperties.lean     Valid glob patterns contain no shell metacharacters
   IntegrityEvents.lean    State machine response to the integrityViolation event
   WorkerLoopProperties.lean  step=transition, buildPrompt preserves the operator prompt
@@ -67,6 +67,7 @@ specs/                 qed's own specs (dogfooding)
   state-machine.spec.toml  State machine correctness — 13 proofs + agent
   parser.spec.toml         Parser correctness — 6 proofs + agent
   verify-mode.spec.toml    Verify mode correctness — 1 proof + commands + agent
+  ignore.spec.toml         .qedignore and glob correctness — 7 proofs + command + agent
   conventions.spec.toml    Convention adherence — naming, DRY, doc accuracy
   docs.spec.toml           Documentation accuracy — freshness + agent
 DocGen/
@@ -158,7 +159,7 @@ qed                   # run the binary (.lake/build/bin on PATH via .envrc)
 
 ## Proven properties
 
-The `Qed/Proofs/` directory contains 120+ theorems, every one checked by Lean 4's kernel — no `sorry`, no `native_decide`. See [docs/proven-properties.md](docs/proven-properties.md) for what they guarantee.
+The `Qed/Proofs/` directory contains 130 theorems, every one checked by Lean 4's kernel — no `sorry`, no `native_decide`. See [docs/proven-properties.md](docs/proven-properties.md) for what they guarantee.
 
 ## Repo-specific conventions
 

--- a/Qed/Ignore.lean
+++ b/Qed/Ignore.lean
@@ -5,92 +5,77 @@ namespace Qed.Ignore
 /-- Path to the ignore file (relative to project root). -/
 def ignoreFileName : String := ".qedignore"
 
-/-- Match a single character against a bracket expression like `[abc]` or `[!abc]`.
-    Returns `(matched, remainingPattern)` where remainingPattern is after the `]`.
-    Returns `none` if the bracket expression is malformed (no closing `]`). -/
-private def matchBracket (patternChars : List Char) (character : Char)
-    : Option (Bool × List Char) :=
-  let (negate, rest) := match patternChars with
-    | '!' :: tail => (true, tail)
-    | chars => (false, chars)
-  let rec go (remaining : List Char) (matched : Bool) : Option (Bool × List Char) :=
-    match remaining with
-    | [] => none
-    | ']' :: tail =>
-      let result := if negate then !matched else matched
-      some (result, tail)
-    | low :: '-' :: high :: tail =>
-      if high == ']' then
-        let hit := character == low || character == '-'
-        let result := if negate then !(matched || hit) else (matched || hit)
-        some (result, tail)
-      else
-        go tail (matched || (low ≤ character && character ≤ high))
-    | c :: tail =>
-      go tail (matched || c == character)
-  go rest false
+/-- Scan the body of a bracket expression, after any leading `!`.
+    Returns whether `character` is in the set, and the pattern remaining after
+    the closing `]`. `none` when there is no closing `]`. -/
+def scanBracket (negate : Bool) (character : Char) :
+    List Char → Bool → Option (Bool × List Char)
+  | [], _ => none
+  | ']' :: tail, matched => some (if negate then !matched else matched, tail)
+  | low :: '-' :: high :: tail, matched =>
+    if high == ']' then
+      let hit := character == low || character == '-'
+      some (if negate then !(matched || hit) else matched || hit, tail)
+    else
+      scanBracket negate character tail
+        (matched || (low ≤ character && character ≤ high))
+  | c :: tail, matched => scanBracket negate character tail (matched || c == character)
 
-/-- Inner loop for fnmatch. Backtracking on `*` means structural recursion
-    cannot be proved — each backtrack resets `pat` to a saved position while
-    advancing `str` by one, so termination is O(p×n) but not structurally
-    decreasing. Marked partial since this is runtime-only code. -/
-private partial def fnmatchGo (pat : List Char) (str : List Char)
-    (starPat : Option (List Char)) (starString : Option (List Char)) : Bool :=
-  match pat, str with
-  | [], [] => true
-  | [], _ =>
-    match starPat, starString with
-    | some sp, some ss =>
-      match ss with
-      | [] => false
-      | _ :: rest => fnmatchGo sp rest (some sp) (some rest)
-    | _, _ => false
-  | '*' :: patRest, _ =>
-    fnmatchGo patRest str (some patRest) (some str)
-  | '?' :: patRest, c :: strRest =>
-    if c == '/' then
-      match starPat, starString with
-      | some sp, some ss =>
-        match ss with
-        | [] => false
-        | _ :: rest => fnmatchGo sp rest (some sp) (some rest)
-      | _, _ => false
-    else
-      fnmatchGo patRest strRest starPat starString
+/-- Match a single character against a bracket expression like `[abc]`,
+    `[!abc]`, or `[a-z]`. -/
+def matchBracket (patternChars : List Char) (character : Char) :
+    Option (Bool × List Char) :=
+  match patternChars with
+  | '!' :: tail => scanBracket true character tail false
+  | chars => scanBracket false character chars false
+
+/-- A bracket expression consumes at least its closing `]`, so what remains is
+    strictly shorter. This is what makes `matchGlob` terminate. -/
+theorem scanBracket_shrinks {negate : Bool} {character : Char}
+    {chars : List Char} {matched result : Bool} {rest : List Char}
+    (h : scanBracket negate character chars matched = some (result, rest)) :
+    rest.length < chars.length := by
+  fun_induction scanBracket negate character chars matched <;> simp_all <;> omega
+
+theorem matchBracket_shrinks {chars : List Char} {character : Char}
+    {result : Bool} {rest : List Char}
+    (h : matchBracket chars character = some (result, rest)) :
+    rest.length < chars.length := by
+  unfold matchBracket at h
+  split at h
+  · exact Nat.lt_succ_of_lt (scanBracket_shrinks h)
+  · exact scanBracket_shrinks h
+
+-- The `h` binder below is used only by `decreasing_by`, which the
+-- unused-variable linter does not scan.
+set_option linter.unusedVariables false in
+/-- Match a pattern against a name, character by character.
+    `*` consumes any run of characters, including `/`; `?` consumes exactly one
+    character that is not `/`; `[…]` consumes one character from the class. -/
+def matchGlob : List Char → List Char → Bool
+  | [], str => str.isEmpty
+  | '*' :: patRest, [] => matchGlob patRest []
+  | '*' :: patRest, c :: strRest =>
+    matchGlob patRest (c :: strRest) || matchGlob ('*' :: patRest) strRest
+  | _ :: _, [] => false
+  | '?' :: patRest, c :: strRest => c != '/' && matchGlob patRest strRest
   | '[' :: patRest, c :: strRest =>
-    match matchBracket patRest c with
-    | some (true, remaining) => fnmatchGo remaining strRest starPat starString
-    | _ =>
-      match starPat, starString with
-      | some sp, some ss =>
-        match ss with
-        | [] => false
-        | _ :: rest => fnmatchGo sp rest (some sp) (some rest)
-      | _, _ => false
-  | p :: patRest, c :: strRest =>
-    if p == c then
-      fnmatchGo patRest strRest starPat starString
-    else
-      match starPat, starString with
-      | some sp, some ss =>
-        match ss with
-        | [] => false
-        | _ :: rest => fnmatchGo sp rest (some sp) (some rest)
-      | _, _ => false
-  | _ :: _, [] =>
-    match starPat, starString with
-    | some sp, some ss =>
-      match ss with
-      | [] => false
-      | _ :: rest => fnmatchGo sp rest (some sp) (some rest)
-    | _, _ => false
+    match h : matchBracket patRest c with
+    | some (true, remaining) => matchGlob remaining strRest
+    | _ => false
+  | p :: patRest, c :: strRest => p == c && matchGlob patRest strRest
+termination_by pat str => pat.length + str.length
+decreasing_by
+  all_goals simp_all
+  all_goals try omega
+  all_goals (have := matchBracket_shrinks h; omega)
 
 /-- Match a name against a glob pattern (fnmatch-style).
-    Supports: `*` (any sequence), `?` (any single char),
-    `[abc]` (character class), `[!abc]` (negated class), `[a-z]` (range).
-    Uses the two-pointer backtracking algorithm (iterative, O(p×n) worst case). -/
+    Supports: `*` (any sequence, separators included), `?` (any single
+    character except `/`), `[abc]` (character class), `[!abc]` (negated class),
+    `[a-z]` (range). -/
 def fnmatch (pattern : String) (name : String) : Bool :=
-  fnmatchGo pattern.toList name.toList none none
+  matchGlob pattern.toList name.toList
 
 /-- Parse a .qedignore file into a list of patterns.
     Format: one pattern per line, `#` for comments, blank lines skipped. -/

--- a/Qed/Proofs/IgnoreProperties.lean
+++ b/Qed/Proofs/IgnoreProperties.lean
@@ -6,10 +6,14 @@ namespace Qed.Proofs.IgnoreProperties
 
 open Qed Qed.Ignore
 
-/-! # .qedignore parsing and pattern precedence
+/-! # .qedignore parsing, glob semantics, and pattern precedence -/
 
-The precedence theorems treat `fnmatch` as an abstract predicate, so they hold
-however globbing itself behaves. -/
+/-- A pattern character with no special meaning to `matchGlob`. -/
+def isLiteralChar (c : Char) : Bool := c != '*' && c != '?' && c != '['
+
+-- ═══════════════════════════════════════════════════════════════════
+-- parseIgnoreFile output contract
+-- ═══════════════════════════════════════════════════════════════════
 
 /-- Blank lines are dropped, so no downstream match is ever attempted against
     the empty pattern. -/
@@ -31,6 +35,106 @@ theorem parseIgnoreFile_no_comments (contents : String) :
   have hcond := hmem.2
   simp only [Bool.and_eq_true, Bool.not_eq_true'] at hcond
   exact hcond.2
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Glob semantics
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **`*` semantics:** a leading `*` matches exactly when some suffix of the
+    name matches the rest of the pattern. -/
+theorem matchGlob_star_iff_suffix (patRest str : List Char) :
+    matchGlob ('*' :: patRest) str = true ↔
+      ∃ suffix, suffix <:+ str ∧ matchGlob patRest suffix = true := by
+  induction str with
+  | nil =>
+    constructor
+    · intro h
+      exact ⟨[], List.nil_suffix, by simpa [matchGlob] using h⟩
+    · rintro ⟨suffix, hsuf, hm⟩
+      have hnil : suffix = [] := List.eq_nil_of_suffix_nil hsuf
+      subst hnil
+      simpa [matchGlob] using hm
+  | cons c s ih =>
+    rw [show matchGlob ('*' :: patRest) (c :: s)
+          = (matchGlob patRest (c :: s) || matchGlob ('*' :: patRest) s) from by
+            simp [matchGlob]]
+    simp only [Bool.or_eq_true]
+    constructor
+    · rintro (h | h)
+      · exact ⟨c :: s, List.suffix_refl _, h⟩
+      · obtain ⟨suffix, hsuf, hm⟩ := ih.mp h
+        exact ⟨suffix, hsuf.trans (List.suffix_cons c s), hm⟩
+    · rintro ⟨suffix, hsuf, hm⟩
+      rcases List.suffix_cons_iff.mp hsuf with rfl | hsuf'
+      · exact Or.inl hm
+      · exact Or.inr (ih.mpr ⟨suffix, hsuf', hm⟩)
+
+/-- A bare `*` matches every name, path separators included — so `*` in a
+    `.qedignore` ignores the whole tree, not just its top level. -/
+theorem star_matches_everything (str : List Char) : matchGlob ['*'] str = true := by
+  induction str with
+  | nil => simp [matchGlob]
+  | cons c s ih => simp [matchGlob, ih]
+
+/-- **`?` semantics:** exactly one character, and never a path separator. -/
+theorem question_matches_one (patRest str : List Char) (c : Char) :
+    matchGlob ('?' :: patRest) (c :: str) = true ↔
+      c ≠ '/' ∧ matchGlob patRest str = true := by
+  simp [matchGlob]
+
+private theorem literal_ne {p : Char} (hlit : isLiteralChar p = true) :
+    p ≠ '*' ∧ p ≠ '?' ∧ p ≠ '[' := by
+  unfold isLiteralChar at hlit
+  simp only [Bool.and_eq_true, bne_iff_ne, ne_eq] at hlit
+  exact ⟨hlit.1.1, hlit.1.2, hlit.2⟩
+
+private theorem matchGlob_literal_nil {p : Char} (ps : List Char)
+    (hlit : isLiteralChar p = true) : matchGlob (p :: ps) [] = false := by
+  have h := literal_ne hlit
+  rw [matchGlob]
+  all_goals simp_all
+
+private theorem matchGlob_literal_cons {p : Char} (ps str : List Char) (c : Char)
+    (hlit : isLiteralChar p = true) :
+    matchGlob (p :: ps) (c :: str) = (p == c && matchGlob ps str) := by
+  have h := literal_ne hlit
+  rw [matchGlob]
+  all_goals simp_all
+
+/-- **Literal semantics:** a pattern with no wildcards is an exact-match test —
+    it matches its own text and nothing else. -/
+theorem literal_matches_iff (pattern str : List Char)
+    (hlit : pattern.all isLiteralChar = true) :
+    matchGlob pattern str = true ↔ pattern = str := by
+  induction pattern generalizing str with
+  | nil => cases str <;> simp [matchGlob]
+  | cons p ps ih =>
+    simp only [List.all_cons, Bool.and_eq_true] at hlit
+    cases str with
+    | nil => simp [matchGlob_literal_nil ps hlit.1]
+    | cons c cs =>
+      rw [matchGlob_literal_cons ps cs c hlit.1]
+      simp only [Bool.and_eq_true, beq_iff_eq]
+      rw [ih cs hlit.2]
+      constructor
+      · rintro ⟨rfl, rfl⟩; rfl
+      · intro h; injection h with h1 h2; exact ⟨h1, h2⟩
+
+/-- A literal prefix followed by `*` matches every name carrying that prefix. -/
+theorem literal_star_matches_prefix (literal rest : List Char)
+    (hlit : literal.all isLiteralChar = true) :
+    matchGlob (literal ++ ['*']) (literal ++ rest) = true := by
+  induction literal with
+  | nil => simpa using star_matches_everything rest
+  | cons p ps ih =>
+    simp only [List.all_cons, Bool.and_eq_true] at hlit
+    simp only [List.cons_append]
+    rw [matchGlob_literal_cons (ps ++ ['*']) (ps ++ rest) p hlit.1]
+    simp [ih hlit.2]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- shouldIgnore precedence
+-- ═══════════════════════════════════════════════════════════════════
 
 /-- Last matching pattern wins, positive direction: a trailing plain pattern
     that matches ignores the name whatever the earlier patterns decided. -/

--- a/Tests/Ignore.lean
+++ b/Tests/Ignore.lean
@@ -59,6 +59,50 @@ def testFnmatchBracketNegated : IO Bool := do
   -- Arrange / Act / Assert
   return fnmatch "[!0-9]" "a" && !fnmatch "[!0-9]" "5"
 
+-- fnmatch: backtracking
+
+def testFnmatchRepeatedStarsBacktrack : IO Bool := do
+  -- Arrange / Act / Assert
+  return fnmatch "*a*a*a*" "aaaa" && fnmatch "*a*b*c*" "xxaxxbxxcxx" &&
+    !fnmatch "*a*a*a*" "aa" && fnmatch "a**b" "ab" && fnmatch "*a" "aa"
+
+def testFnmatchStarWithTrailingWildcards : IO Bool := do
+  -- Arrange / Act / Assert
+  return fnmatch "*?" "ab" && fnmatch "?*" "ab" && fnmatch "*[ab]" "xb" &&
+    !fnmatch "*[ab]" "xc"
+
+-- fnmatch: path separators
+
+def testFnmatchStarCrossesSeparator : IO Bool := do
+  -- Arrange / Act / Assert
+  return fnmatch "*" "a/b" && fnmatch "a*b" "a/x/b" &&
+    fnmatch "*.log" "dir/x.log" && fnmatch "*/*" "a/b"
+
+def testFnmatchQuestionRejectsSeparator : IO Bool := do
+  -- Arrange / Act / Assert
+  return !fnmatch "?" "/" && !fnmatch "a?b" "a/b" && fnmatch "a?b" "axb"
+
+def testFnmatchBracketAcceptsSeparator : IO Bool := do
+  -- Arrange / Act / Assert
+  return fnmatch "[/]" "/" && fnmatch "[a/]" "/" && fnmatch "[a-c]*" "b/x"
+
+-- fnmatch: malformed bracket expressions
+
+def testFnmatchUnterminatedBracketNeverMatches : IO Bool := do
+  -- Arrange / Act / Assert
+  return !fnmatch "[" "[" && !fnmatch "[abc" "a" && !fnmatch "a[b" "a[b"
+
+def testFnmatchEmptyBracketClasses : IO Bool := do
+  -- Arrange / Act / Assert
+  return !fnmatch "[]" "]" && fnmatch "[!]" "]" && fnmatch "[a-]" "-"
+
+-- fnmatch: empty pattern and name
+
+def testFnmatchEmpty : IO Bool := do
+  -- Arrange / Act / Assert
+  return fnmatch "" "" && !fnmatch "" "a" && fnmatch "*" "" &&
+    !fnmatch "?" ""
+
 -- fnmatch: combined wildcards
 
 def testFnmatchCombined : IO Bool := do
@@ -105,6 +149,14 @@ def ignoreTests : List (String × IO Bool) := [
   ("testFnmatchBracketClass", testFnmatchBracketClass),
   ("testFnmatchBracketRange", testFnmatchBracketRange),
   ("testFnmatchBracketNegated", testFnmatchBracketNegated),
+  ("testFnmatchRepeatedStarsBacktrack", testFnmatchRepeatedStarsBacktrack),
+  ("testFnmatchStarWithTrailingWildcards", testFnmatchStarWithTrailingWildcards),
+  ("testFnmatchStarCrossesSeparator", testFnmatchStarCrossesSeparator),
+  ("testFnmatchQuestionRejectsSeparator", testFnmatchQuestionRejectsSeparator),
+  ("testFnmatchBracketAcceptsSeparator", testFnmatchBracketAcceptsSeparator),
+  ("testFnmatchUnterminatedBracketNeverMatches", testFnmatchUnterminatedBracketNeverMatches),
+  ("testFnmatchEmptyBracketClasses", testFnmatchEmptyBracketClasses),
+  ("testFnmatchEmpty", testFnmatchEmpty),
   ("testFnmatchCombined", testFnmatchCombined),
   ("testShouldIgnoreBasic", testShouldIgnoreBasic),
   ("testShouldIgnoreNegation", testShouldIgnoreNegation),

--- a/docs/proven-properties.md
+++ b/docs/proven-properties.md
@@ -100,16 +100,27 @@ A proof criterion's target is split into a module and a theorem name, and the mo
 | `VerifierProperties.lean` | `isValidModuleName_iff` | **[spec]** Accepted module names carry no shell metacharacters      |
 | `VerifierProperties.lean` | `containsSorry_iff`     | **[spec]** `sorry` is detected exactly on identifier boundaries     |
 
-## `.qedignore` decides coverage predictably
+## `.qedignore` matching is total and its glob semantics are proven
 
-Blank lines and comments never become patterns, so nothing is silently matched against them. Precedence is last-matching-pattern-wins in both directions: a trailing plain pattern ignores a spec, a trailing `!` pattern brings it back. These hold however glob matching itself behaves, because they treat `fnmatch` as an abstract predicate.
+Glob matching terminates on every input — the matcher recurses only on arguments that decrease `pattern.length + name.length`, with the bracket case justified by the fact that a bracket expression always consumes at least its closing `]`. Nothing about `.qedignore` handling is opaque to the kernel.
 
-| File                    | Theorem                        | Guarantee                                           |
-| ----------------------- | ------------------------------ | --------------------------------------------------- |
-| `IgnoreProperties.lean` | `parseIgnoreFile_no_empty`     | Blank lines never become patterns                   |
-| `IgnoreProperties.lean` | `parseIgnoreFile_no_comments`  | Comment lines never become patterns                 |
-| `IgnoreProperties.lean` | `shouldIgnore_append_positive` | A trailing matching pattern ignores the spec        |
-| `IgnoreProperties.lean` | `shouldIgnore_append_negated`  | A trailing matching `!` pattern un-ignores the spec |
+The wildcards mean what the documentation says. A leading `*` matches exactly when some suffix of the name matches the rest of the pattern, which makes a bare `*` match everything including nested paths — `*` deliberately crosses `/`, while `?` deliberately does not. A pattern with no wildcards is an exact-match test: it matches its own text and nothing else, so `archive` never accidentally ignores `archived-specs`.
+
+Blank lines and comments never become patterns. Precedence is last-matching-pattern-wins in both directions: a trailing plain pattern ignores a spec, a trailing `!` pattern brings it back.
+
+| File                    | Theorem                        | Guarantee                                                                 |
+| ----------------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| `IgnoreProperties.lean` | `matchGlob_star_iff_suffix`    | **[spec]** `*` matches iff some suffix of the name matches the rest       |
+| `IgnoreProperties.lean` | `star_matches_everything`      | **[spec]** A bare `*` matches every name, separators included             |
+| `IgnoreProperties.lean` | `question_matches_one`         | **[spec]** `?` matches exactly one character and never `/`                |
+| `IgnoreProperties.lean` | `literal_matches_iff`          | **[spec]** A wildcard-free pattern matches its own text and nothing else  |
+| `IgnoreProperties.lean` | `literal_star_matches_prefix`  | **[spec]** A literal prefix plus `*` matches every name with that prefix  |
+| `IgnoreProperties.lean` | `parseIgnoreFile_no_comments`  | **[spec]** Comment lines never become patterns                            |
+| `IgnoreProperties.lean` | `parseIgnoreFile_no_empty`     | Blank lines never become patterns                                         |
+| `IgnoreProperties.lean` | `shouldIgnore_append_negated`  | **[spec]** A trailing matching `!` pattern un-ignores the spec            |
+| `IgnoreProperties.lean` | `shouldIgnore_append_positive` | A trailing matching pattern ignores the spec                              |
+| `Ignore.lean`           | `scanBracket_shrinks`          | A bracket expression consumes at least its `]` — the termination argument |
+| `Ignore.lean`           | `matchBracket_shrinks`         | The same, through the optional leading `!`                                |
 
 ## A spec survives serialization unchanged
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -61,11 +61,15 @@ Four formal proofs verify output correctness: the result complete partition (eve
 
 Six formal proofs verify pure functions used in verification dispatch and shell execution: `targetToModule` returns the module prefix iff the target has at least two dot-separated parts, `isValidModuleName` accepts only shell-safe identifier segments, `containsSorry` detects exactly standalone sorry occurrences, `shellQuote` turns any string into exactly one shell word that decodes back to it (including the empty string), and the command is always the trailing segment of a built shell invocation. An agent review verifies the dispatch logic: exhaustive match on all VerifyType constructors, platform-aware shell execution, output truncation preserving the most recent output, and correct result mappings.
 
-### 8. Convention adherence (`conventions.spec.toml`)
+### 8. Ignore correctness (`ignore.spec.toml`)
+
+Seven formal proofs verify `.qedignore` handling: a leading `*` matches iff some suffix of the name matches the rest of the pattern, a bare `*` matches everything including nested paths, `?` matches exactly one character and never `/`, a wildcard-free pattern is an exact-match test, a literal prefix plus `*` matches every name with that prefix, comments never become patterns, and the last matching pattern decides. A structural assertion keeps the matcher total — `Qed/Ignore.lean` must contain no `partial`. An agent review checks pattern-form coverage and the honesty of the termination measure.
+
+### 9. Convention adherence (`conventions.spec.toml`)
 
 Agent reviews check naming conventions (full variable names, no abbreviations), DRY compliance (no duplicated logic, no dead code), and documentation accuracy (AGENTS.md and CONVENTIONS.md consistent with the actual codebase).
 
-### 9. Documentation accuracy (`docs.spec.toml`)
+### 10. Documentation accuracy (`docs.spec.toml`)
 
 Generated docs (schema, format reference) must be fresh. Hand-written docs (architecture, README) must be consistent with the actual codebase. Agent reviews cross-reference docs against source.
 

--- a/qed.lock
+++ b/qed.lock
@@ -18,7 +18,7 @@
       {"path":
        "Tests/Ignore.lean",
        "hash":
-       "b914e5dfae2a624cc3745d2963670f0486b0f97c9c4d55c4d6324baecbd22e84"},
+       "3a7857c235603ab789cb0c15051c48ae543cbf2a229876cdaebc3057887ac3df"},
       {"path":
        "Tests/Integration.lean",
        "hash":
@@ -262,6 +262,65 @@
        "theorem:Qed.Proofs.VerifierProperties.containsSorry_iff",
        "hash":
        "a6c81108adb8be6b4c4955d8169b72382d42c6ccd8caf3d738be27cb01db5a5f"}]}]},
+  {"specPath":
+   "./specs/ignore.spec.toml",
+   "criteria":
+   [{"description":
+     "Glob matching is total — no partial definitions in Ignore.lean",
+     "artifacts":
+     [{"path":
+       "Qed/Ignore.lean",
+       "hash":
+       "322055b596f56137f6eebfa0bb2c1f39639bbcc0f08627035f3f5eab441bdb2f"}]},
+    {"description":
+     "A leading * matches iff some suffix of the name matches the rest of the pattern",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.matchGlob_star_iff_suffix",
+       "hash":
+       "617626ae2b0ae0057e0aab5d015e1053de822e79fbdec6744c249f27e1524c26"}]},
+    {"description":
+     "A bare * matches every name, path separators included",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.star_matches_everything",
+       "hash":
+       "b174ffdfb753f2c3437a54992ebec88069725280dabc46e13cfe814e5b044c10"}]},
+    {"description":
+     "? matches exactly one character and never a path separator",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.question_matches_one",
+       "hash":
+       "d7038368bf5fe9aed8f348ecfb767e8e3fd9826c79244a7b7a8b03aca43a730c"}]},
+    {"description":
+     "A pattern with no wildcards matches its own text and nothing else",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.literal_matches_iff",
+       "hash":
+       "52d613e395c13b8e8eb5be7ee1424a28b619759407350b4f4b70cb0c92633503"}]},
+    {"description":
+     "A literal prefix followed by * matches every name carrying that prefix",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.literal_star_matches_prefix",
+       "hash":
+       "92577e1753b11eb94d5ffc87a21255433eec97fb5eaf224a70c3b7a4bc805dda"}]},
+    {"description":
+     "Blank lines and comments never become ignore patterns",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.parseIgnoreFile_no_comments",
+       "hash":
+       "c622dc8050b7eb343fc0a7c8492b69ea8128e22d65b3306cd996de171a52e853"}]},
+    {"description":
+     "The last matching pattern decides, in both directions including ! negation",
+     "artifacts":
+     [{"path":
+       "theorem:Qed.Proofs.IgnoreProperties.shouldIgnore_append_negated",
+       "hash":
+       "d79d2fd9d2e38938975253a27c7c79fa2b3e59d922dd3899cf43d8d8909ee7e6"}]}]},
   {"specPath":
    "./specs/verify-mode.spec.toml",
    "criteria":

--- a/specs/ignore.spec.toml
+++ b/specs/ignore.spec.toml
@@ -1,0 +1,101 @@
+#:schema ../docs/spec.schema.json
+
+# Ignore handling — .qedignore parsing, glob matching, and pattern precedence.
+# Owns Qed/Ignore.lean and Qed/Proofs/IgnoreProperties.lean.
+
+name = "ignore-correctness"
+
+# --- Structural assertions ---
+
+[[criteria]]
+description = "Glob matching is total — no partial definitions in Ignore.lean"
+
+[criteria.verify]
+type = "command"
+run = "! grep -q 'partial' Qed/Ignore.lean"
+lock = ["Qed/Ignore.lean"]
+
+# --- Proof criteria ---
+
+[[criteria]]
+description = "A leading * matches iff some suffix of the name matches the rest of the pattern"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.matchGlob_star_iff_suffix"
+
+[[criteria]]
+description = "A bare * matches every name, path separators included"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.star_matches_everything"
+
+[[criteria]]
+description = "? matches exactly one character and never a path separator"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.question_matches_one"
+
+[[criteria]]
+description = "A pattern with no wildcards matches its own text and nothing else"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.literal_matches_iff"
+
+[[criteria]]
+description = "A literal prefix followed by * matches every name carrying that prefix"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.literal_star_matches_prefix"
+
+[[criteria]]
+description = "Blank lines and comments never become ignore patterns"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.parseIgnoreFile_no_comments"
+
+[[criteria]]
+description = "The last matching pattern decides, in both directions including ! negation"
+
+[criteria.verify]
+type = "proof"
+prover = "lean4"
+target = "Qed.Proofs.IgnoreProperties.shouldIgnore_append_negated"
+
+# --- Agent review ---
+
+[[criteria]]
+description = """
+Glob matching handles every pattern form correctly and the ignore decision \
+matches documented .qedignore semantics."""
+
+[criteria.verify]
+type = "agent"
+prompt = """
+Review Qed/Ignore.lean. Verify:
+
+1. `matchGlob` handles every pattern form: `*`, `?`, `[abc]`, `[a-z]`, `[!abc]`,
+   and literal characters — with no unreachable or duplicated match arm
+2. `scanBracket` consumes through the closing `]` and reports a malformed
+   bracket (no closing `]`) as a non-match rather than a partial match
+3. The termination measure is honest — `matchGlob` recurses only on arguments
+   that decrease `pattern.length + name.length`, with the bracket case justified
+   by `matchBracket_shrinks`
+4. `shouldIgnore` applies patterns in order with `!` negation, and the last
+   matching pattern decides
+5. `parseIgnoreFile` drops blank lines and comments and trims trailing whitespace
+
+Report any pattern form handled incorrectly, any asymmetry between `*` and `?`
+that is not deliberate, or any way a malformed pattern could match unexpectedly.
+"""


### PR DESCRIPTION
## Summary

`Qed/Ignore.lean` decides which specs get verified at all, so a wrong answer silently drops verification coverage rather than failing loudly. Until now its matcher was `partial`: star backtracking reset the pattern pointer while advancing the string pointer, so it was not structurally decreasing, and a `partial def` is opaque to the kernel with no equational lemmas. Nothing about glob matching could be stated, let alone proven — the precedence proofs on `main` only work because they treat `fnmatch` as an abstract predicate.

This replaces the matcher with a structurally terminating one and proves the semantics.

**Based on `feat/lockfile-roundtrip-proof` (#40), not `main`.** Review #40 first; this PR's diff against it is the three files below plus docs.

## The matcher

`matchGlob` recurses on `pattern.length + name.length`, which strictly decreases in every branch. The bracket case is the only one that needs an argument: `scanBracket_shrinks` proves a bracket expression always consumes at least its closing `]`, so the pattern remaining after it is strictly shorter.

To state that lemma, `matchBracket` is restructured from a `let rec` closure capturing `negate` and `character` into a top-level `scanBracket` that takes its state explicitly. The lemma then falls out by functional induction.

`Qed/Ignore.lean` now contains no `partial`, and `specs/ignore.spec.toml` has a structural criterion that fails the build if one reappears.

## Behaviour is unchanged, and that was checked before the swap

The eight new cases in `Tests/Ignore.lean` were written and committed **against the old implementation** (`1ae6ead`), where they pass — they characterize today's behaviour, not the new code's. They cover repeated-star backtracking, trailing wildcards after a star, separator handling, unterminated brackets, the `[]` and `[!]` edge classes, and empty pattern/name.

On top of that, old and new were compared exhaustively during development:

| Alphabet                                                 | Pairs    | Differences |
| -------------------------------------------------------- | -------- | ----------- |
| patterns ≤ 4 over `a b * ? / [ ] ! -`, names ≤ 4 over `a b /` | 893,101  | 0           |
| patterns ≤ 5 over `a * ? / [ ]`, names ≤ 5 over `a /`         | 587,853  | 0           |
| patterns ≤ 7 over `a b *`, names ≤ 7 over `a b`               | 836,400  | 0           |

The old implementation is deleted outright — no compatibility shim, no equivalence theorem against dead code.

## What is now proven

- `matchGlob_star_iff_suffix` — **`*` semantics:** a leading `*` matches exactly when some suffix of the name matches the rest of the pattern
- `star_matches_everything` — a bare `*` matches every name, path separators included, so `*` in a `.qedignore` ignores the whole tree rather than just its top level
- `question_matches_one` — **`?` semantics:** exactly one character, and never `/`
- `literal_matches_iff` — a pattern with no wildcards is an exact-match test: it matches its own text and nothing else, so `archive` cannot accidentally ignore `archived-specs`
- `literal_star_matches_prefix` — a literal prefix followed by `*` matches every name carrying that prefix

One thing worth flagging for review, because it is now pinned by proof: **`*` crosses `/` but `?` does not.** That asymmetry is pre-existing behaviour, not something this PR introduces — I verified it against the old matcher before writing the theorems. If it is wrong, it is a deliberate separate decision to make, and the proofs will now force the conversation instead of leaving it implicit.

## Dogfooding

New `specs/ignore.spec.toml` owns the subsystem: seven proof criteria, the no-`partial` structural assertion, and an agent review covering pattern-form coverage and the honesty of the termination measure. It brings qed's self-verification to **10 specs**.

## Test plan

- `lake build` — clean, no warnings
- `lake test` — **all 165 tests passed** (157 + the 8 new characterization cases)
- `devbox run check` — build, tests, and both docgen freshness diffs clean
- `qed verify --auto` — **all 10 specs passed**
- `npx prettier@3 --check .` — clean
- `qed lock` regenerated for the new spec
- Pre-push hook (`lake build` + `qed verify --auto --pin`) passed; `--pin` changed no hashes

No `partial` and no `sorry` in `Qed/Ignore.lean`; no `native_decide` anywhere in the repo.

**GitHub Actions reports no checks on this PR** — `.github/workflows/ci.yml` triggers only on pull requests targeting `main`, and this one targets `feat/lockfile-roundtrip-proof`. CI will run once #40 merges and this retargets. The local run above is the same gate CI executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
